### PR TITLE
Fix Bugs from PR #1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "request": "launch",
       "name": "Launch Program",
       "skipFiles": ["<node_internals>/**", "node_modules/**"],
-      "program": "${workspaceFolder}/dist/src/index.js",
+      "program": "${workspaceFolder}/dist/index.js",
       "preLaunchTask": "npm: build",
       "console": "integratedTerminal"
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "npx eslint src/**/*.ts",
     "lint:fix": "npx eslint --fix src/**/*.ts && npx eslint --fix test/**/*.ts",
     "prebuild": "npm run clean:dist",
-    "build": "tsc",
+    "build": "tsc --project tsconfig.prod.json",
     "start": "node dist/src/index",
     "start:dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "pretest": "npm run build",


### PR DESCRIPTION
Since only `src` is output to the `dist` folder, then `index.js` is now at the top level. This broke the lauch configuration for debugging.

The `build` task also was not correct since `tsc` could not find a file named simply `tsconfig`

These bugs were introduced in PR #1